### PR TITLE
Atualizando Jasmine para versão 2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "node ./tests/test_setup.js",
-    "unit-test": "jasmine-node --verbose tests/unit",
+    "unit-test": "JASMINE_CONFIG_PATH=tests/unit/jasmine.json jasmine",
     "integration-test": "NODE_ENV=test node ./tests/integration/run_tests.js",
     "test": "npm run unit-test",
     "start": "node index.js"
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "frisby": "^0.8.5",
-    "jasmine-node": "^1.14.5",
+    "jasmine": "^2.4.1",
     "q": "^1.4.1"
   }
 }

--- a/src/db.connection.js
+++ b/src/db.connection.js
@@ -1,17 +1,20 @@
 var mongoose = require('mongoose');
 
-var connectionURL = {
-  development: 'mongodb://localhost/vamosjuntas',
-  test: 'mongodb://localhost/vamosjuntas_test',
-  production: process.env.MONGODB_URI
+var connectionURL = function () {
+  var environment = process.env.NODE_ENV || 'test';
+
+  return {
+    development: 'mongodb://localhost/vamosjuntas',
+    test: 'mongodb://localhost/vamosjuntas_test',
+    production: process.env.MONGODB_URI
+  }[environment];
 };
 
 var open = function (mode) {
-  var enviroment = process.env.NODE_ENV;
   var connection;
   var options = { promiseLibrary: require('q').Promise };
 
-  mongoose.createConnection(connectionURL[enviroment], options);
+  mongoose.createConnection(connectionURL(), options);
   mongoose.set('Promise', require('q').Promise);
   connection = mongoose.connection;
   connection.on('error', console.error.bind(console, 'connection error:'));

--- a/tests/unit/app/app_spec.js
+++ b/tests/unit/app/app_spec.js
@@ -3,12 +3,13 @@ var place = require('../../../src/domains/place.model');
 
 describe('App', function () {
   var server, app;
-  app = require('../../../src/server.js');
 
   beforeEach(function () {
-    server = createSpyObj('server', ['get', 'post', 'listen', 'use']);
-    spyOn(restify, 'createServer').andReturn(server);
-    spyOn(restify, 'queryParser').andReturn(jasmine.any(Function));
+    server = jasmine.createSpyObj('server', ['get', 'post', 'listen', 'use']);
+    spyOn(restify, 'createServer').and.returnValue(server);
+    spyOn(restify, 'queryParser').and.returnValue(jasmine.any(Function));
+
+    app = require('../../../src/server.js');
   });
 
   describe('start', function () {
@@ -33,10 +34,10 @@ describe('App', function () {
 
     beforeEach(function() {
       var mongoResponse;
-      mongoResponse = createSpyObj('mongoResponse', ['exec']);
-      spyOn(place, 'find').andReturn(mongoResponse);
+      mongoResponse = jasmine.createSpyObj('mongoResponse', ['exec']);
+      spyOn(place, 'find').and.returnValue(mongoResponse);
       app.start();
-      risks = server.get.mostRecentCall.args[1];
+      risks = server.get.calls.mostRecent().args[1];
     });
 
     it('should call mongo with the correct parameters',function() {
@@ -58,7 +59,7 @@ describe('App', function () {
 
     it('should return a error when there is no coordinates', function() {
       request = {params: {}};
-      response = createSpyObj('response', ['send']);
+      response = jasmine.createSpyObj('response', ['send']);
 
       risks(request, response);
 

--- a/tests/unit/controllers/report-risk_spec.js
+++ b/tests/unit/controllers/report-risk_spec.js
@@ -28,7 +28,7 @@ describe('Create a new risk report', function () {
   });
 
   it('should return 201 when all data is ok', function(done) {
-    spyOn(placeService, 'create').andReturn(Promise.resolve());
+    spyOn(placeService, 'create').and.returnValue(Promise.resolve());
     reportRisk(restifyMock.request, restifyMock.response, restifyMock.next);
     setTimeout(function() {
       expect(placeService.create).toHaveBeenCalledWith(restifyMock.request.params);
@@ -44,8 +44,8 @@ describe('Create a new risk report', function () {
   });
 
   it('should return 201 after validating with jsonschema', function(done) {
-    spyOn(placeService, 'create').andReturn(Promise.resolve());
-    spyOn(jsonschema, 'validate').andCallThrough();
+    spyOn(placeService, 'create').and.returnValue(Promise.resolve());
+    spyOn(jsonschema, 'validate').and.callThrough();
     reportRisk(restifyMock.request, restifyMock.response, restifyMock.next);
     setTimeout(function(){
       expect(jsonschema.validate).toHaveBeenCalledWith(restifyMock.request.params, schema);
@@ -55,7 +55,7 @@ describe('Create a new risk report', function () {
   });
 
   it('should call Place.create but fail to create a risk', function(done) {
-    spyOn(placeService, 'create').andReturn(Promise.reject());
+    spyOn(placeService, 'create').and.returnValue(Promise.reject());
     reportRisk(restifyMock.request, restifyMock.response, restifyMock.next);
       setTimeout(function(){
       expect(placeService.create).toHaveBeenCalledWith(restifyMock.request.params);

--- a/tests/unit/db.connection_spec.js
+++ b/tests/unit/db.connection_spec.js
@@ -1,21 +1,55 @@
-var db = require('../../src/db.connection');
 var mongoose = require('mongoose');
 
 describe('db connection', function () {
+  var db;
+
+  beforeEach(function () {
+    spyOn(mongoose, 'createConnection');
+    spyOn(mongoose, 'disconnect');
+  });
+
   describe('open', function () {
-    it('connect to vamosjuntas database', function () {
-      spyOn(mongoose, 'createConnection');
+    beforeEach(function () {
+      process.env.MONGODB_URI = 'mongo-production';
+      db = require('../../src/db.connection');
+    });
 
-      db.open();
+    afterEach(function () {
+      process.env.MONGODB_URI = undefined;
+      process.env.NODE_ENV = undefined;
+    });
 
-      expect(mongoose.createConnection).toHaveBeenCalledWith('mongodb://localhost/vamosjuntas_test', jasmine.any(Object));
+    describe('production environment', function () {
+      it('connect to vamosjuntas database', function () {
+        process.env.NODE_ENV = 'production';
+
+        db.open();
+
+        expect(mongoose.createConnection).toHaveBeenCalledWith('mongo-production', jasmine.any(Object));
+      });
+    });
+
+    describe('development environment', function () {
+      it('connect to vamosjuntas database', function () {
+        process.env.NODE_ENV = 'development';
+        db.open();
+
+        expect(mongoose.createConnection).toHaveBeenCalledWith('mongodb://localhost/vamosjuntas', jasmine.any(Object));
+      });
+    });
+
+    describe('test environment', function () {
+      it('connect to vamosjuntas database', function () {
+        process.env.NODE_ENV = 'test';
+        db.open();
+
+        expect(mongoose.createConnection).toHaveBeenCalledWith('mongodb://localhost/vamosjuntas_test', jasmine.any(Object));
+      });
     });
   });
 
   describe('close', function () {
     it('disconnect from vamosjuntas database', function () {
-      spyOn(mongoose, 'disconnect');
-
       db.close();
 
       expect(mongoose.disconnect).toHaveBeenCalled();

--- a/tests/unit/jasmine.json
+++ b/tests/unit/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "tests/unit",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": true
+}

--- a/tests/unit/services/place-service-spec.js
+++ b/tests/unit/services/place-service-spec.js
@@ -11,15 +11,15 @@ describe('Place Service', function() {
   var params = {a: 1};
 
   it('should call Place.create and creates a risk with success', function(done){
-    spyOn(Place, 'create').andReturn(Promise.resolve());
+    spyOn(Place, 'create').and.returnValue(Promise.resolve());
     placeService.create(params).should.be.fulfilled.and.notify(done);
     expect(Place.create).toHaveBeenCalledWith(params);
   });
 
   it('should call Place.create and reject when does not create a risk with success', function(done){
-    spyOn(Place, 'create').andReturn(Promise.reject());
+    spyOn(Place, 'create').and.returnValue(Promise.reject());
     placeService.create(params).should.be.rejected.and.notify(done);
     expect(Place.create).toHaveBeenCalledWith(params);
   });
-  
+
 });


### PR DESCRIPTION
Estávamos presos na versão 1.3.1 por causa do jasmine-node.
closes #17 .

Ainda não está finalizado. Faltando migrar os integration tests. Caso alguém deseje continuar, poderia criar um `jasmine.json` só para integration, indicar o mesmo no arquivo `run_tests.js` e alterar as chamadas para as funções que mudaram de nome.
